### PR TITLE
Refactor: 캐시 키 세분화

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
@@ -63,9 +63,6 @@ public class Cloth {
   @JoinColumn(name = "owner_id")
   private User user;
 
-  @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<ClothWithAttributes> clothesWithAttributes;
-
   public static final String FIELD_CREATED_AT = "createdAt";
 
   @Builder
@@ -78,17 +75,6 @@ public class Cloth {
     this.clothType = clothType;
     this.clothesImageUrl = clothesImageUrl;
     this.user = user;
-    this.clothesWithAttributes = Optional.ofNullable(clothesWithAttributes)
-        .orElse(new ArrayList<>());
-  }
-
-  public void addAttribute(ClothWithAttributes attributes) {
-    this.clothesWithAttributes.add(attributes);
-    attributes.setClothes(this);
-  }
-
-  public void clearAttributes() {
-    this.clothesWithAttributes.clear();
   }
 
   public void updateName(String name) {

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
@@ -63,7 +63,7 @@ public class Cloth {
   @JoinColumn(name = "owner_id")
   private User user;
 
-  @BatchSize(size = 100)
+  //  @BatchSize(size = 100)
   @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ClothWithAttributes> clothesWithAttributes;
 
@@ -95,6 +95,7 @@ public class Cloth {
   public void updateName(String name) {
     this.name = name;
   }
+
   public void updateType(ClothType clothType) {
     this.clothType = clothType;
   }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Cloth.java
@@ -63,7 +63,6 @@ public class Cloth {
   @JoinColumn(name = "owner_id")
   private User user;
 
-  //  @BatchSize(size = 100)
   @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ClothWithAttributes> clothesWithAttributes;
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
@@ -62,9 +62,5 @@ public class ClothWithAttributes {
     this.cloth = cloth;
     this.attribute = attribute;
   }
-
-  protected void setClothes(Cloth cloth) {
-    this.cloth = cloth;
-  }
 }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
@@ -49,7 +49,6 @@ public class ClothWithAttributes {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "definition_id")
-  @BatchSize(size = 100)
   private Attribute attribute;
 
   @Builder

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
@@ -12,24 +12,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ClothMapper {
 
-  public ClothesDto toDto(Cloth cloth, String imageUrl) {
-    List<ClothesAttributeWithDefDto> clothesAttributeWithDefDtos = cloth.getClothesWithAttributes()
-        .stream()
-        .map(attr -> new ClothesAttributeWithDefDto(
-            attr.getAttribute().getId(),
-            attr.getAttribute().getName(),
-            attr.getAttribute().getSelectableValues(),
-            attr.getValue()
-        ))
-        .toList();
-
+  public ClothesDto toDto(Cloth cloth, String imageUrl, List<ClothWithAttributes> attributes) {
     return ClothesDto.builder()
         .id(cloth.getId())
         .ownerId(cloth.getUser().getId())
         .name(cloth.getName())
         .imageUrl(imageUrl)
         .type(cloth.getClothType())
-        .attributes(clothesAttributeWithDefDtos)
+        .attributes(toAttributeDefDto(attributes))
         .build();
 
   }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/RecommendClothesMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/RecommendClothesMapper.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.clothes.mapper;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeWithDefDto;
 import com.codeit.weatherwear.domain.clothes.dto.response.RecommendClothesDto;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,25 +12,29 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RecommendClothesMapper {
 
-  public RecommendClothesDto toDto(Cloth cloth, String imageUrl) {
-    List<ClothesAttributeWithDefDto> clothesAttributeWithDefDtos = cloth.getClothesWithAttributes()
-        .stream()
-        .map(attr -> new ClothesAttributeWithDefDto(
-            attr.getAttribute().getId(),
-            attr.getAttribute().getName(),
-            attr.getAttribute().getSelectableValues(),
-            attr.getValue()
-        ))
-        .toList();
-
+  public RecommendClothesDto toDto(Cloth cloth, String imageUrl,
+      List<ClothWithAttributes> clothesAttributeWithDefs) {
     return RecommendClothesDto.builder()
         .clothesId(cloth.getId())
         .ownerId(cloth.getUser().getId())
         .name(cloth.getName())
         .imageUrl(imageUrl)
         .type(cloth.getClothType())
-        .attributes(clothesAttributeWithDefDtos)
+        .attributes(toAttributeDefDto(clothesAttributeWithDefs))
         .build();
 
+  }
+
+  public List<ClothesAttributeWithDefDto> toAttributeDefDto(List<ClothWithAttributes> attrs) {
+    return attrs
+        .stream().map(
+            attr -> new ClothesAttributeWithDefDto(
+                attr.getAttribute().getId(),
+                attr.getAttribute().getName(),
+                attr.getAttribute().getSelectableValues(),
+                attr.getValue()
+            )
+        )
+        .toList();
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
@@ -12,16 +12,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ClothRepository extends JpaRepository<Cloth, UUID>, ClothRepositoryCustom {
 
-  @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
-  @Query("SELECT c FROM Cloth c WHERE c.id = :clothId")
-  Optional<Cloth> findByIdWithAttributes(UUID clothId);
-
-  @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
-  @Query("SELECT c FROM Cloth c WHERE c.id IN :clothIds")
-  List<Cloth> findAllByIdWithAttributes(List<UUID> clothIds);
-
-  @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
-  @Query("SELECT c FROM Cloth c WHERE c.user.id = :userId")
-  List<Cloth> findAllWithAttributesByUserId(UUID userId);
-
+  List<Cloth> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClothRepository extends JpaRepository<Cloth, UUID>, ClothRepositoryCustom {
-/*
 
   @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
   @Query("SELECT c FROM Cloth c WHERE c.id = :clothId")
@@ -24,6 +23,5 @@ public interface ClothRepository extends JpaRepository<Cloth, UUID>, ClothReposi
   @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
   @Query("SELECT c FROM Cloth c WHERE c.user.id = :userId")
   List<Cloth> findAllWithAttributesByUserId(UUID userId);
-*/
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustom.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustom.java
@@ -21,10 +21,4 @@ public interface ClothRepositoryCustom {
 
   Long getTotalCount(UUID ownerId, ClothType typeEqual);
 
- /* Optional<Cloth> findByIdWithAttributes(UUID clothId);
-
-  List<Cloth> findAllByIdWithAttributes(List<UUID> clothIds);
-
-  List<Cloth> findAllWithAttributesByUserId(UUID userId);
-*/
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustom.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustom.java
@@ -21,10 +21,10 @@ public interface ClothRepositoryCustom {
 
   Long getTotalCount(UUID ownerId, ClothType typeEqual);
 
-  Optional<Cloth> findByIdWithAttributes(UUID clothId);
+ /* Optional<Cloth> findByIdWithAttributes(UUID clothId);
 
   List<Cloth> findAllByIdWithAttributes(List<UUID> clothIds);
 
   List<Cloth> findAllWithAttributesByUserId(UUID userId);
-
+*/
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustomImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryCustomImpl.java
@@ -71,7 +71,7 @@ public class ClothRepositoryCustomImpl implements ClothRepositoryCustom {
         .where(builder)
         .fetchOne();
   }
-
+/*
   @Override
   public Optional<Cloth> findByIdWithAttributes(UUID clothId) {
     QCloth cloth = QCloth.cloth;
@@ -104,6 +104,6 @@ public class ClothRepositoryCustomImpl implements ClothRepositoryCustom {
         .selectFrom(cloth)
         .where(cloth.user.id.eq(userId))
         .fetch();
-  }
+  }*/
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothWithAttributesRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothWithAttributesRepository.java
@@ -10,8 +10,15 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClothWithAttributesRepository extends JpaRepository<ClothWithAttributes, UUID> {
+
   @Query("SELECT DISTINCT cwa.value FROM ClothWithAttributes cwa " +
       "WHERE cwa.attribute.id = :attributeId")
   List<String> findUsedValuesByAttribute(@Param("attributeId") UUID attributeId);
 
+  @Query("SELECT DISTINCT cwa FROM ClothWithAttributes cwa " +
+      "JOIN FETCH cwa.attribute " +
+      "WHERE cwa.cloth.id IN :clothIds")
+  List<ClothWithAttributes> findByClothIdIn(@Param("clothIds") List<UUID> clothIds);
+
+  void deleteAllByClothId(UUID clothId);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -17,6 +17,7 @@ import com.codeit.weatherwear.domain.clothes.exception.cloth.NotSupportSiteExcep
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.repository.ClothWithAttributesRepository;
 import com.codeit.weatherwear.domain.clothes.service.parser.SiteParser;
 import com.codeit.weatherwear.domain.recommendation.service.AIRecommendationService;
 import com.codeit.weatherwear.domain.user.entity.User;
@@ -29,6 +30,7 @@ import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,6 +65,7 @@ public class ClothServiceImpl implements ClothService {
   private final ClothMapper clothMapper;
   private final List<SiteParser> siteParsers;
   private final AIRecommendationService aiRecommendationService;
+  private final ClothWithAttributesRepository clothWithAttributesRepository;
 
   /**
    * 의상 등록
@@ -94,6 +97,7 @@ public class ClothServiceImpl implements ClothService {
         .clothesImageUrl(thumbnailKey)
         .user(user)
         .build();
+    Cloth savedCloth = clothRepository.save(cloth);
 
     List<UUID> attributesIds = request.attributes().stream()
         .map(ClothesAttributeDto::definitionId).toList();
@@ -105,14 +109,16 @@ public class ClothServiceImpl implements ClothService {
     Map<UUID, Attribute> attrMap = attributesList.stream()
         .collect(Collectors.toMap(Attribute::getId, Function.identity()));
 
-    applyAttributesToCloth(request.attributes(), attrMap, cloth);
+    List<ClothWithAttributes> attrEntities = new ArrayList<>();
+    applyAttributesToCloth(request.attributes(), attrMap, savedCloth, attrEntities);
+    clothWithAttributesRepository.saveAll(attrEntities);
 
-    Cloth savedCloth = clothRepository.save(cloth);
     log.info("[Creating Cloth Completed] Id: {}, Cloth Name: {}", savedCloth.getId(),
         savedCloth.getName());
     String imageUrl = thumbnailKey != null ? thumbnailImageStorage.get(thumbnailKey) : null;
+
     aiRecommendationService.evictRecommendationCache(user);
-    return clothMapper.toDto(savedCloth, imageUrl);
+    return clothMapper.toDto(savedCloth, imageUrl, attrEntities);
   }
 
   /**
@@ -192,7 +198,7 @@ public class ClothServiceImpl implements ClothService {
   @Override
   public ClothesDto update(UUID clothesId, ClothesUpdateRequest request, MultipartFile image) {
     log.info("[Start Updating Cloth] ID: {}, Cloth Name: {}", clothesId, request.name());
-    Cloth cloth = clothRepository.findByIdWithAttributes(clothesId)
+    Cloth cloth = clothRepository.findById(clothesId)
         .orElseThrow(() -> {
           log.warn("[Fail Updating Cloth] ID: {}, Cloth Name: {}", clothesId, request.name());
           return new ClothNotFoundException();
@@ -230,26 +236,29 @@ public class ClothServiceImpl implements ClothService {
     if (request.type() != null) {
       cloth.updateType(request.type());
     }
-    //속성 수정 경우
-    List<UUID> attrIds = request.attributes().stream()
-        .map(ClothesAttributeDto::definitionId)
-        .toList();
-    List<Attribute> attributes = attributeRepository.findAllById(attrIds);
 
+    //속성 수정 경우
+    List<ClothWithAttributes> savedAttributes = List.of();
     if (request.attributes() != null) {
-      cloth.clearAttributes();
+      clothWithAttributesRepository.deleteAllByClothId(clothesId);
+      List<UUID> attrIds = request.attributes().stream()
+          .map(ClothesAttributeDto::definitionId)
+          .toList();
+      List<Attribute> attributes = attributeRepository.findAllById(attrIds);
+
       Map<UUID, Attribute> attributeMap = attributes.stream()
           .collect(Collectors.toMap(Attribute::getId, Function.identity()));
-
-      applyAttributesToCloth(request.attributes(), attributeMap, cloth);
-
+      List<ClothWithAttributes> attrEntities = new ArrayList<>();
+      applyAttributesToCloth(request.attributes(), attributeMap, cloth, attrEntities);
+      savedAttributes = clothWithAttributesRepository.saveAll(
+          attrEntities);
     }
     User user = cloth.getUser();
     if (user != null) {
       aiRecommendationService.evictRecommendationCache(user);
     }
     log.info("[Updating Cloth Completed] ID : {}, Name: {}", clothesId, cloth.getName());
-    return clothMapper.toDto(cloth, imageUrl);
+    return clothMapper.toDto(cloth, imageUrl, savedAttributes);
   }
 
   @Override
@@ -279,15 +288,22 @@ public class ClothServiceImpl implements ClothService {
     List<UUID> ids = clothesList.stream()
         .map(Cloth::getId)
         .toList();
-    List<Cloth> clothesWithAttrs = clothRepository.findAllByIdWithAttributes(ids);
+    //fetch join으로 속성까지 같이 갖고옴
+    List<ClothWithAttributes> clothesWithAttrs = clothWithAttributesRepository.findByClothIdIn(ids);
 
-    List<ClothesDto> data = clothesWithAttrs.stream()
+    //clothId기준 그룹화
+    Map<UUID, List<ClothWithAttributes>> grouped =
+        clothesWithAttrs.stream().collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
+
+    //dto매핑
+    List<ClothesDto> data = clothesList.stream()
         .map(cloth -> {
           String imageUrl =
               cloth.getClothesImageUrl() != null
                   ? thumbnailImageStorage.get(cloth.getClothesImageUrl())
                   : null;
-          return clothMapper.toDto(cloth, imageUrl);
+          List<ClothWithAttributes> attrs = grouped.getOrDefault(cloth.getId(), List.of());
+          return clothMapper.toDto(cloth, imageUrl, attrs);
         })
         .toList();
     log.debug("[Response Result] Count Changed To ClothesDto: {}", data.size());
@@ -345,9 +361,9 @@ public class ClothServiceImpl implements ClothService {
     log.info("[Deleting Cloth Completed] ID: {}", clothesId);
   }
 
-  private static void applyAttributesToCloth(List<ClothesAttributeDto> attributeDtos,
+  private void applyAttributesToCloth(List<ClothesAttributeDto> attributeDtos,
       Map<UUID, Attribute> attrMap,
-      Cloth cloth) {
+      Cloth cloth, List<ClothWithAttributes> attrEntities) {
     for (ClothesAttributeDto dto : attributeDtos) {
       Attribute attribute = attrMap.get(dto.definitionId());
       if (attribute == null) {
@@ -360,18 +376,15 @@ public class ClothServiceImpl implements ClothService {
             dto.definitionId());
         throw new InvalidAttributeValueException();
       }
-
-      ClothWithAttributes attr = ClothWithAttributes.builder()
-          .value(dto.value())
-          .attribute(attribute)
+      ClothWithAttributes entity = ClothWithAttributes.builder()
           .cloth(cloth)
+          .attribute(attribute)
+          .value(dto.value())
           .build();
 
-      cloth.addAttribute(attr);
+      attrEntities.add(entity);
     }
     log.debug("[Applying Attributes Completed]");
-
   }
-
 }
 

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
@@ -1,11 +1,13 @@
 package com.codeit.weatherwear.domain.ootd.mapper;
 
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
 import com.codeit.weatherwear.domain.ootd.entity.Ootd;
 import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +25,7 @@ public class OotdMapper {
         .build();
   }
 
-  public OotdDto toDto(Ootd ootd) {
+  public OotdDto toDto(Ootd ootd, List<ClothWithAttributes> attrs) {
     Cloth cloth = ootd.getCloth();
     String imageUrl =
         cloth.getClothesImageUrl() != null ? thumbnailImageStorage.get(cloth.getClothesImageUrl())
@@ -34,7 +36,7 @@ public class OotdMapper {
         .name(cloth.getName())
         .imageUrl(imageUrl)
         .type(cloth.getClothType().toString())
-        .attributes(clothMapper.toAttributeDefDto(cloth.getClothesWithAttributes()))
+        .attributes(clothMapper.toAttributeDefDto(attrs))
         .build();
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImpl.java
@@ -1,7 +1,9 @@
 package com.codeit.weatherwear.domain.ootd.service.impl;
 
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.repository.ClothWithAttributesRepository;
 import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
 import com.codeit.weatherwear.domain.ootd.entity.Ootd;
@@ -9,7 +11,9 @@ import com.codeit.weatherwear.domain.ootd.mapper.OotdMapper;
 import com.codeit.weatherwear.domain.ootd.repository.OotdRepository;
 import com.codeit.weatherwear.domain.ootd.service.OotdService;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,7 @@ public class OotdServiceImpl implements OotdService {
 
   private final OotdRepository ootdRepository;
   private final ClothRepository clothRepository;
+  private final ClothWithAttributesRepository clothWithAttributesRepository;
 
   private final OotdMapper ootdMapper;
 
@@ -41,7 +46,17 @@ public class OotdServiceImpl implements OotdService {
 
     List<Ootd> savedList = ootdRepository.saveAll(ootdList);
 
-    return savedList.stream().map(ootdMapper::toDto).toList();
+    List<UUID> clothIdList = clothesList.stream().map(Cloth::getId).toList();
+    Map<UUID, List<ClothWithAttributes>> groupedAttrs = clothWithAttributesRepository
+        .findByClothIdIn(clothIdList)
+        .stream()
+        .collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
+
+    return savedList.stream().map(ootd -> {
+      List<ClothWithAttributes> attrs = groupedAttrs.getOrDefault(ootd.getCloth().getId(),
+          List.of());
+      return ootdMapper.toDto(ootd, attrs);
+    }).toList();
   }
 
   @Transactional
@@ -49,8 +64,20 @@ public class OotdServiceImpl implements OotdService {
   public List<OotdDto> findOotdByFeedId(UUID feedId) {
 
     List<Ootd> ootds = ootdRepository.findByFeedId(feedId);
+    List<UUID> clothIds = ootds.stream()
+        .map(o -> o.getCloth().getId())
+        .toList();
 
-    return ootds.stream().map(ootdMapper::toDto).toList();
+    Map<UUID, List<ClothWithAttributes>> groupedAttrs = clothWithAttributesRepository
+        .findByClothIdIn(clothIds)
+        .stream()
+        .collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
+
+    return ootds.stream().map(ootd -> {
+      List<ClothWithAttributes> attrs =
+          groupedAttrs.getOrDefault(ootd.getCloth().getId(), List.of());
+      return ootdMapper.toDto(ootd, attrs);
+    }).toList();
   }
 
   @Transactional
@@ -58,8 +85,25 @@ public class OotdServiceImpl implements OotdService {
   public List<OotdDto> deleteOotdByFeedId(UUID feedId) {
 
     List<Ootd> ootds = ootdRepository.findByFeedId(feedId);
+    List<UUID> clothIds = ootds.stream()
+        .map(o -> o.getCloth().getId())
+        .toList();
+
+    Map<UUID, List<ClothWithAttributes>> groupedAttrs = clothWithAttributesRepository
+        .findByClothIdIn(clothIds)
+        .stream()
+        .collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
+
+    List<OotdDto> dtos = ootds.stream()
+        .map(ootd -> {
+          List<ClothWithAttributes> attrs =
+              groupedAttrs.getOrDefault(ootd.getCloth().getId(), List.of());
+          return ootdMapper.toDto(ootd, attrs);
+        })
+        .toList();
+    
     ootdRepository.deleteAll(ootds);
 
-    return ootds.stream().map(ootdMapper::toDto).toList();
+    return dtos;
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/AIRecommendationService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/AIRecommendationService.java
@@ -1,7 +1,9 @@
 package com.codeit.weatherwear.domain.recommendation.service;
 
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.repository.ClothWithAttributesRepository;
 import com.codeit.weatherwear.domain.recommendation.exception.GeminiParseException;
 import com.codeit.weatherwear.domain.recommendation.external.GeminiApiClient;
 import com.codeit.weatherwear.domain.user.entity.User;
@@ -14,7 +16,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -28,6 +32,7 @@ public class AIRecommendationService {
 
   private final ClothRepository clothRepository;
   private final GeminiApiClient geminiApiClient;
+  private final ClothWithAttributesRepository clothWithAttributesRepository;
 
   @Cacheable(
       value = "recommendations",
@@ -46,7 +51,8 @@ public class AIRecommendationService {
 
     //응답 파싱 - 결과 의상 ID목록
     List<UUID> filteredNameByLLM = parseResponse(response);
-    return clothRepository.findAllByIdWithAttributes(filteredNameByLLM);
+    List<Cloth> recommendedClothes = clothRepository.findAllById(filteredNameByLLM);
+    return recommendedClothes;
   }
 
   @CacheEvict(value = "recommendations", key = "#user.id.toString() + '_' + #user.temperatureSensitivity")
@@ -64,18 +70,28 @@ public class AIRecommendationService {
 
   private String getClothesInfo(List<Cloth> cloths) {
     StringBuilder clothesInfo = new StringBuilder("옷 정보 \n");
+    List<UUID> clothIds = cloths.stream()
+        .map(Cloth::getId)
+        .toList();
+    List<ClothWithAttributes> attrs = clothWithAttributesRepository.findByClothIdIn(clothIds);
+    Map<UUID, List<ClothWithAttributes>> grouped =
+        attrs.stream().collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
     for (Cloth cloth : cloths) {
       clothesInfo.append("ID: ").append(cloth.getId()).append("\n");
       clothesInfo.append("이름: ").append(cloth.getName()).append("\n");
       clothesInfo.append("타입: ").append(cloth.getClothType()).append("\n");
       clothesInfo.append("속성: \n");
-      cloth.getClothesWithAttributes().forEach(attr -> {
+      List<ClothWithAttributes> cwaList = grouped.getOrDefault(cloth.getId(), List.of());
+      for (ClothWithAttributes cwa : cwaList) {
         clothesInfo.append(" - ")
-            .append(attr.getAttribute().getName()).append(": ")
-            .append(attr.getValue()).append("\n");
-      });
+            .append(cwa.getAttribute().getName())
+            .append(": ")
+            .append(cwa.getValue())
+            .append("\n");
+      }
       clothesInfo.append("\n");
     }
+    System.out.println(clothesInfo);
     return String.valueOf(clothesInfo.append("\n"));
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/AIRecommendationService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/AIRecommendationService.java
@@ -29,9 +29,14 @@ public class AIRecommendationService {
   private final ClothRepository clothRepository;
   private final GeminiApiClient geminiApiClient;
 
-  @Cacheable(value = "recommendations",
-      key = "#user.id.toString() + '_' + #user.temperatureSensitivity",
-      condition = "#weather.skyStatus != null && #weather.temperature != null && #weather.humidity != null && #weather.windSpeed != null && #weather.precipitation != null")
+  @Cacheable(
+      value = "recommendations",
+      key = "#user.id.toString() + '_' + #user.temperatureSensitivity + '_' + "
+          + "(#weather.location != null ? #weather.location.name : 'unknown') + '_' + "
+          + "T(com.codeit.weatherwear.domain.recommendation.util.WeatherBucket).bucketizeTemp(#weather.temperature.current) + '_' + "
+          + "(#weather.skyStatus != null ? #weather.skyStatus : 'unknown')",
+      condition = "#weather.skyStatus != null && #weather.temperature != null"
+  )
   public List<Cloth> getRecommendationCandidates(List<Cloth> filtered, User user, Weather weather
   ) {
     log.info("[CACHE CHECK] - Cache Start");
@@ -120,6 +125,5 @@ public class AIRecommendationService {
     }
     return list;
   }
-
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/CacheMetricsService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/CacheMetricsService.java
@@ -1,0 +1,26 @@
+package com.codeit.weatherwear.domain.recommendation.service;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CacheMetricsService {
+
+  private final CacheManager cacheManager;
+
+  public void logRecommendationCacheStats() {
+    CaffeineCache cache = (CaffeineCache) cacheManager.getCache("recommendations");
+    if (cache != null) {
+      CacheStats stats = cache.getNativeCache().stats();
+      log.info("[Cache Stats] Hits: {}, Misses:{}, Hit Rate:{}"
+          , stats.hitCount(), stats.missCount(), stats.hitRate());
+    }
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RandomRecommendService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RandomRecommendService.java
@@ -3,7 +3,9 @@ package com.codeit.weatherwear.domain.recommendation.service;
 import com.codeit.weatherwear.domain.clothes.dto.response.RecommendClothesDto;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
 import com.codeit.weatherwear.domain.clothes.entity.ClothType;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.mapper.RecommendClothesMapper;
+import com.codeit.weatherwear.domain.clothes.repository.ClothWithAttributesRepository;
 import com.codeit.weatherwear.domain.recommendation.dto.response.RecommendationDto;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
@@ -12,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,7 @@ public class RandomRecommendService {
 
   private final RecommendClothesMapper recommendClothesMapper;
   private final ThumbnailImageStorage thumbnailImageStorage;
+  private final ClothWithAttributesRepository clothWithAttributesRepository;
 
   public RecommendationDto recommend(List<Cloth> candidates, User user, Weather weather) {
     // 타입별 그룹핑
@@ -54,13 +58,27 @@ public class RandomRecommendService {
       getRandomCloth(grouped.get(type), false).ifPresent(finalRecommendation::add);
     }
 
+    List<UUID> clothIds = finalRecommendation.stream()
+        .map(Cloth::getId)
+        .toList();
+
+    List<ClothWithAttributes> clothesWithAttrs =
+        clothWithAttributesRepository.findByClothIdIn(clothIds);
+
+    // clothId 기준 그룹화
+    Map<UUID, List<ClothWithAttributes>> groupedAttrs =
+        clothesWithAttrs.stream()
+            .collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
+
     // DTO 변환 + 썸네일 처리
     List<RecommendClothesDto> recommendedClothes = finalRecommendation.stream()
         .map(cloth -> {
           String imageUrl = cloth.getClothesImageUrl() != null
               ? thumbnailImageStorage.get(cloth.getClothesImageUrl())
               : null;
-          return recommendClothesMapper.toDto(cloth, imageUrl);
+          List<ClothWithAttributes> attrs = groupedAttrs.getOrDefault(cloth.getId(), List.of());
+
+          return recommendClothesMapper.toDto(cloth, imageUrl, attrs);
         })
         .toList();
 

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RecommendationServiceImpl.java
@@ -43,6 +43,7 @@ public class RecommendationServiceImpl implements RecommendationService {
   private final ClothRepository clothRepository;
   private final RandomRecommendService randomRecommendService;
   private final AIRecommendationService aiRecommendationService;
+  private final CacheMetricsService cacheMetricsService;
 
   /**
    * 의상 추천
@@ -85,6 +86,7 @@ public class RecommendationServiceImpl implements RecommendationService {
       );
       log.info("[Recommendation] Filtered Candidates By LLM Completed, count: {}",
           filteredByAI.size());
+      cacheMetricsService.logRecommendationCacheStats();
 
       // filteredByAI가 비어있을 경우 fallback 처리
       if (filteredByAI.isEmpty()) {

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/service/RecommendationServiceImpl.java
@@ -1,7 +1,9 @@
 package com.codeit.weatherwear.domain.recommendation.service;
 
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.repository.ClothWithAttributesRepository;
 import com.codeit.weatherwear.domain.recommendation.attributeCategory.AttributeType;
 import com.codeit.weatherwear.domain.recommendation.attributeCategory.Season;
 import com.codeit.weatherwear.domain.recommendation.attributeCategory.Thickness;
@@ -44,6 +46,7 @@ public class RecommendationServiceImpl implements RecommendationService {
   private final RandomRecommendService randomRecommendService;
   private final AIRecommendationService aiRecommendationService;
   private final CacheMetricsService cacheMetricsService;
+  private final ClothWithAttributesRepository clothWithAttributesRepository;
 
   /**
    * 의상 추천
@@ -66,10 +69,25 @@ public class RecommendationServiceImpl implements RecommendationService {
     });
     log.debug("[Recommendation] User: {}, Weather: {}", user.getId(), weather.getId());
 
-    List<Cloth> clothes = clothRepository.findAllWithAttributesByUserId(user.getId());
+    List<Cloth> clothes = clothRepository.findAllByUserId(user.getId());
+    if (clothes.isEmpty()) {
+      log.info("[Recommendation] No clothes found for user: {}", user.getId());
+      return RecommendationDto.builder()
+          .weatherId(weatherId)
+          .userId(user.getId())
+          .clothes(List.of())
+          .build();
+    }
+
+    List<UUID> clothIds = clothes.stream().map(Cloth::getId).toList();
+    List<ClothWithAttributes> allAttributes =
+        clothWithAttributesRepository.findByClothIdIn(clothIds);
+    Map<UUID, List<ClothWithAttributes>> groupedAttrs =
+        allAttributes.stream()
+            .collect(Collectors.groupingBy(cwa -> cwa.getCloth().getId()));
 
     //날씨에 적당한 옷 타입마다 필터링하기
-    List<Cloth> filtered = filterCloth(user, weather, clothes);
+    List<Cloth> filtered = filterCloth(user, weather, clothes, groupedAttrs);
     log.info("[Recommendation] Filter Cloth By Thick & Season Completed, count: {}",
         filtered.size());
 
@@ -101,7 +119,8 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
   }
 
-  private List<Cloth> filterCloth(User user, Weather weather, List<Cloth> cloths) {
+  private List<Cloth> filterCloth(User user, Weather weather, List<Cloth> cloths,
+      Map<UUID, List<ClothWithAttributes>> groupedAttrs) {
     //체감온도 계산
     double apparent = calculateApparentTemperature(weather);
 
@@ -112,7 +131,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     //옷 필터링
     log.info("[Recommendation] Filter Cloth start");
     return cloths.stream()
-        .filter(c -> isSuitable(c, adjusted))
+        .filter(c -> isSuitable(c, adjusted, groupedAttrs))
         .toList();
   }
 
@@ -164,17 +183,20 @@ public class RecommendationServiceImpl implements RecommendationService {
         - 4.686035;
   }
 
-  private boolean isSuitable(Cloth cloth, double temp) {
+  private boolean isSuitable(Cloth cloth, double temp,
+      Map<UUID, List<ClothWithAttributes>> groupedAttrs) {
+    List<ClothWithAttributes> attrs = groupedAttrs.getOrDefault(cloth.getId(), List.of());
+
     // 옷의 속성 리스트를 가져와 Map 형태로 변환하여 쉽게 접근
-    Map<String, String> attributeMap = toAttributeMap(cloth);
+    Map<String, String> attributeMap = toAttributeMap(attrs);
 
     //체감온도에 따른 계절, 두께 조건 적용
     return matchSeasonConstraint(attributeMap.get(AttributeType.SEASON.getKey()), temp)
         && matchThicknessConstraint(attributeMap.get(AttributeType.THICKNESS.getKey()), temp);
   }
 
-  private Map<String, String> toAttributeMap(Cloth cloth) {
-    return cloth.getClothesWithAttributes().stream()
+  private Map<String, String> toAttributeMap(List<ClothWithAttributes> attrs) {
+    return attrs.stream()
         .collect(Collectors.toMap(
             attr -> attr.getAttribute().getName().toLowerCase(),
             attr -> attr.getValue().toLowerCase()

--- a/src/main/java/com/codeit/weatherwear/domain/recommendation/util/WeatherBucket.java
+++ b/src/main/java/com/codeit/weatherwear/domain/recommendation/util/WeatherBucket.java
@@ -1,0 +1,22 @@
+package com.codeit.weatherwear.domain.recommendation.util;
+
+public class WeatherBucket {
+
+  public static String bucketizeTemp(Double temp) {
+    if (temp == null) {
+      return "unknown";
+    }
+    if (temp < 0) {
+      return "below0";
+    } else if (temp < 10) {
+      return "0to10";
+    } else if (temp < 20) {
+      return "10to20";
+    } else if (temp < 30) {
+      return "20to30";
+    } else {
+      return "30plus";
+    }
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/global/config/CacheConfig.java
+++ b/src/main/java/com/codeit/weatherwear/global/config/CacheConfig.java
@@ -36,6 +36,7 @@ public class CacheConfig {
         Caffeine.newBuilder()
             .expireAfterWrite(600, TimeUnit.SECONDS)
             .maximumSize(1000)
+            .recordStats()
             .build()
     ));
 


### PR DESCRIPTION
### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📑 변경 사항
> 캐시 키 세분화 진행하였습니다. `사용자 id+ 민감도+ 지역+날씨 온도(범주화)+하늘상태`
히트율 로그 남기는 코드 추가하였습니다.
N+1문제 해결
1. 양방향 관계 제거
2. 중간테이블을 이용하여 의상에 따른 속성조회

### ✅ 추가코멘트
사용자 id와 민감도로만 키를 설정했었는데 이 경우, 응답속도만을 개선하고 추천 품질은 파괴하는 코드였습니다.
따라서 히트율은 낮아지더라도 날씨까지 키에 포함시켜 추천 품질을 올리고자 노력하였습니다.

중간테이블로 조회하면 되기때문에 양방향 관계를 설정할 필요가 없다고 판단하였습니다.
양방향 관계를 제거하고 중간테이블로 속성을 조회한 후 옷ID로 group으로 묶어 속성과 같이 조회되도록 설정하였습니다.